### PR TITLE
fix: add lang=en to all pages and also add lang=tr to specific parts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -71,7 +71,7 @@
     </div>
   </section>
 
-  <section class="hero is-warning">
+  <section class="hero is-warning" lang="tr">
     <div class="hero-body">
       <div class="container is-max-widescreen">
         <div class="content">

--- a/pages/about.html
+++ b/pages/about.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -72,7 +72,7 @@
 <!-- CONTENT -->
 
 <a id="yeni-ogrenciler"></a>
-<section class="hero">
+<section class="hero" lang="tr">
   <div class="hero-body">
     <div class="container is-max-widescreen">
       <div class="content">

--- a/pages/activities.html
+++ b/pages/activities.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/course-catalog.html
+++ b/pages/course-catalog.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/ects-information-packages.html
+++ b/pages/ects-information-packages.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/gp-guide.html
+++ b/pages/gp-guide.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/gt-guide.html
+++ b/pages/gt-guide.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/help-center.html
+++ b/pages/help-center.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/internship.html
+++ b/pages/internship.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/izva-program.html
+++ b/pages/izva-program.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -72,7 +72,7 @@
 
 <!-- CONTENT -->
 
-<section class="section">
+<section class="section" lang="tr">
   <div class="container is-max-widescreen">
     <div class="content">
       <div class="columns">

--- a/pages/master-program.html
+++ b/pages/master-program.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/people.html
+++ b/pages/people.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/phd-program.html
+++ b/pages/phd-program.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/programs.html
+++ b/pages/programs.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/research.html
+++ b/pages/research.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/template.html
+++ b/pages/template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/undergraduate-program.html
+++ b/pages/undergraduate-program.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pages/vbt.html
+++ b/pages/vbt.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Applied `lang="en"` at document level across all pages and introduced scoped `lang="tr"` for Turkish sections to ensure correct behavior for screen readers, translation tools, and search engines.

Files changed: 18  
Reason: W3C accessibility standards (WCAG).